### PR TITLE
Fix null album handling in SongService update

### DIFF
--- a/src/main/java/com/example/resonate/service/SongService.java
+++ b/src/main/java/com/example/resonate/service/SongService.java
@@ -96,12 +96,11 @@ public class SongService {
         songRepository.save(updatedSong);
 
         Album album = updatedSong.getAlbum();
-
-        int duration= album.getSongList().stream().mapToInt(Song::getDuration).sum();
-
-        album.setDuration(duration);
-
-        albumRepository.save(album);
+        if (album != null) {
+            int duration = album.getSongList().stream().mapToInt(Song::getDuration).sum();
+            album.setDuration(duration);
+            albumRepository.save(album);
+        }
 
         return toSongDTO(updatedSong);
     }


### PR DESCRIPTION
## Summary
- avoid NullPointerException when updating songs lacking an album

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8eaeec483319324b2091146bdf2